### PR TITLE
Drawing a game doesn't result in any ELO rating change

### DIFF
--- a/PlayerRank/Scoring/EloScoringStrategy.cs
+++ b/PlayerRank/Scoring/EloScoringStrategy.cs
@@ -52,6 +52,13 @@ namespace PlayerRank.Scoring
                     var playerA = scoreboard.Single(p => p.Name == playerAName);
 
                     var chanceOfPlayerAWinning = ChanceOfWinning(previousScores[playerAName], previousScores[playerBName]);
+
+                    // IF the okayers have drawn then don't update their scores
+                    if (playerAResult == playerBResult)
+                    {
+                        continue;
+                    }
+
                     var didPlayerAWin = (playerAResult > playerBResult);
                     var ratingChange = RatingChange(chanceOfPlayerAWinning, didPlayerAWin);
                     // adjust for the fact that we're playing against multiple people

--- a/UnitTests/EloTests.cs
+++ b/UnitTests/EloTests.cs
@@ -24,6 +24,23 @@ namespace PlayerRank.UnitTests
         }
 
         [Fact]
+        public void DrawCausesNoChangeInScores()
+        {
+            var league = new League();
+
+            var game = new Game();
+
+            game.AddResult("Foo", 100);
+            game.AddResult("Bar", 100);
+
+            league.RecordGame(game);
+
+            var eloScoringStrategy = new EloScoringStrategy(64, 400, 1400);
+            Assert.Equal(1400, league.GetLeaderBoard(eloScoringStrategy).Where(x => x.Name == "Foo").Select(x => x.Score).Single());
+            Assert.Equal(1400, league.GetLeaderBoard(eloScoringStrategy).Where(x => x.Name == "Bar").Select(x => x.Score).Single());
+        }
+
+        [Fact]
         public void FourPlayerGameOneRound()
         {
             var league = new League();

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -16,6 +17,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -84,6 +87,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is to allow tracking games such as table football where players can be equal on number of wins at the end of a round robin of games.