### PR TITLE
Custom Positions to Points map in simple strategy

### DIFF
--- a/PlayerRank/Scoring/Simple/SimpleScoringStrategy.cs
+++ b/PlayerRank/Scoring/Simple/SimpleScoringStrategy.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 
 namespace PlayerRank.Scoring.Simple
 {
     public class SimpleScoringStrategy : IScoringStrategy
     {
-        private readonly Dictionary<Position, Points> m_PositionToPoints = new Dictionary<Position, Points>();
+        private readonly IDictionary<Position, Points> m_PositionToPoints = new Dictionary<Position, Points>();
 
         public SimpleScoringStrategy()
         {
@@ -20,6 +19,11 @@ namespace PlayerRank.Scoring.Simple
             m_PositionToPoints.Add(new Position(8), new Points(3));
             m_PositionToPoints.Add(new Position(9), new Points(2));
             m_PositionToPoints.Add(new Position(10), new Points(1));
+        }
+
+        public SimpleScoringStrategy(IDictionary<Position, Points> pointsMap)
+        {
+            m_PositionToPoints = pointsMap;
         }
 
         public void Reset()

--- a/UnitTests/SimpleLeagueTests.cs
+++ b/UnitTests/SimpleLeagueTests.cs
@@ -102,5 +102,33 @@ namespace PlayerRank.UnitTests
             Assert.Equal(new Position(1), fooResult.Position);
             Assert.Equal(new Position(2), barResult.Position);
         }
+
+        [Fact]
+        public void CanUseCustomPositionToPointsMap()
+        {
+            var league = new League();
+
+            var game = new Game();
+            game.AddResult("Foo", Position.First);
+            game.AddResult("Bar", Position.Second);
+
+            league.RecordGame(game);
+
+            var map = new Dictionary<Position, Points>
+            {
+                {Position.First, new Points(100)},
+                {Position.Second, new Points(1)}
+            };
+
+            var simpleScoringStrategy = new SimpleScoringStrategy(map);
+            var leaderboard = league.GetLeaderBoard(simpleScoringStrategy).ToList();
+            var fooResult = leaderboard.Single(x => x.Name == "Foo");
+            var barResult = leaderboard.Single(x => x.Name == "Bar");
+
+            Assert.Equal(new Points(100), fooResult.Points);
+            Assert.Equal(new Position(1), fooResult.Position);
+            Assert.Equal(new Points(1), barResult.Points);
+            Assert.Equal(new Position(2), barResult.Position);
+        }
     }
 }


### PR DESCRIPTION
This allows for scoring strategies where the number of points scored can be specified by the consumer of PlayerRank rather than being the default linear 10 points for first down to 1 point for tenth.