### PR TITLE
New players change stats

### DIFF
--- a/PlayerRank/League.cs
+++ b/PlayerRank/League.cs
@@ -11,6 +11,7 @@ namespace PlayerRank
     public class League
     {
         private readonly List<Game> m_Games = new List<Game>(); 
+        private readonly List<string> m_Players = new List<string>(); 
 
         /// <summary>
         /// Gets the current leader board for this league based on a specifed scoring strategy
@@ -32,10 +33,20 @@ namespace PlayerRank
         {
             scoringStrategy.Reset();
 
+            var initialGame = new Game();
+
+            foreach (var player in m_Players)
+            {
+                initialGame.AddResult(player, new Points(0));
+            }
+
+            var games = new List<Game> {initialGame};
+            games.AddRange(m_Games);
+
             var history = new List<History>();
             IList<PlayerScore> leaderBoard = new List<PlayerScore>();
 
-            foreach (var game in m_Games)
+            foreach (var game in games)
             {
                 scoringStrategy.UpdateScores(leaderBoard, game);
                 scoringStrategy.SetPositions(leaderBoard);
@@ -51,6 +62,14 @@ namespace PlayerRank
         public void RecordGame(Game game)
         {
             m_Games.Add(game);
+
+            foreach (var player in game.GetResults().Select(x => x.Name))
+            {
+                if (!m_Players.Contains(player))
+                {
+                    m_Players.Add(player);
+                }
+            }
         }
     }
 }

--- a/PlayerRank/Stats/ResultChangeStats.cs
+++ b/PlayerRank/Stats/ResultChangeStats.cs
@@ -18,23 +18,11 @@ namespace PlayerRank.Stats
             foreach (var player in players)
             {
                 var resultA = leaderboardA.Single(x => x.Name == player);
-                var resultB = leaderboardB.SingleOrDefault(x => x.Name == player);
+                var resultB = leaderboardB.Single(x => x.Name == player);
 
-                int positionChange;
-                double pointsChange;
-
-                if (resultB == null)
-                {
-                    positionChange = 0;
-                    pointsChange = 0;
-                }
-                else
-                {
-                    positionChange = -(resultA.Position.GetValue() - resultB.Position.GetValue());
-                    pointsChange = (resultA.Points - resultB.Points).GetValue();
-                }
+                var positionChange = -(resultA.Position.GetValue() - resultB.Position.GetValue());
+                var pointsChange = (resultA.Points - resultB.Points).GetValue();
                 
-
                 changes.Add(new ResultsChange(player, resultA.Position, positionChange, resultA.Points, pointsChange));
             }
 

--- a/PlayerRank/Stats/ResultChangeStats.cs
+++ b/PlayerRank/Stats/ResultChangeStats.cs
@@ -30,7 +30,7 @@ namespace PlayerRank.Stats
                 }
                 else
                 {
-                    positionChange = (resultA.Position.GetValue() - resultB.Position.GetValue());
+                    positionChange = -(resultA.Position.GetValue() - resultB.Position.GetValue());
                     pointsChange = (resultA.Points - resultB.Points).GetValue();
                 }
                 

--- a/UnitTests/HistoryTests.cs
+++ b/UnitTests/HistoryTests.cs
@@ -21,7 +21,7 @@ namespace PlayerRank.UnitTests
             }
 
             var history = league.GetLeaderBoardHistory(new SimpleScoringStrategy()).ToList();
-            var fooAfterFiveGames = history[4].Leaderboard.Single(x => x.Name == "Foo");
+            var fooAfterFiveGames = history[5].Leaderboard.Single(x => x.Name == "Foo");
             var fooMostRecentGame = history.Last().Leaderboard.Single(x => x.Name == "Foo");
 
             Assert.Equal(new Points(25), fooAfterFiveGames.Points);

--- a/UnitTests/ResultChangeStatsTests.cs
+++ b/UnitTests/ResultChangeStatsTests.cs
@@ -47,8 +47,8 @@ namespace PlayerRank.UnitTests
 
             var game2 = new Game();
             game2.AddResult("Foo", new Points(5));
-            game2.AddResult("Bar", new Points(3));
-            game2.AddResult("Bar2", new Points(1));
+            game2.AddResult("Bar", new Points(1));
+            game2.AddResult("Bar2", new Points(3));
 
             league.RecordGame(game2);
 
@@ -58,8 +58,8 @@ namespace PlayerRank.UnitTests
 
             var resultsChangeForFoo = change.Single(x => x.Name == "Bar2");
 
-            Assert.Equal(0, resultsChangeForFoo.PositionChange);
-            Assert.Equal(0, resultsChangeForFoo.PointsChange);
+            Assert.Equal(1, resultsChangeForFoo.PositionChange);
+            Assert.Equal(3, resultsChangeForFoo.PointsChange);
         }
     }
 }

--- a/UnitTests/ResultChangeStatsTests.cs
+++ b/UnitTests/ResultChangeStatsTests.cs
@@ -36,14 +36,11 @@ namespace PlayerRank.UnitTests
         {
             var league = new League();
 
-            for (var i = 0; i < 10; i++)
-            {
-                var game = new Game();
-                game.AddResult("Foo", new Points(5));
-                game.AddResult("Bar", new Points(1));
+            var game = new Game();
+            game.AddResult("Foo", new Points(5));
+            game.AddResult("Bar", new Points(1));
 
-                league.RecordGame(game);
-            }
+            league.RecordGame(game);
 
             var game2 = new Game();
             game2.AddResult("Foo", new Points(5));


### PR DESCRIPTION
- When asking for a new players change in result useful information is now shown rather than just 0 for both the change in position and result.
-  Fixed a bug where position change would in fact have the wrong sign (e.g. -1 for going up 1 place)