### PR TITLE
Upgrade from .NET 7 to .NET 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Build NuGet Package
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/dotnet/sdk:7.0
+    container: mcr.microsoft.com/dotnet/sdk:10.0
 
     steps:
       - name: Install jq
@@ -16,7 +16,7 @@ jobs:
           apt-get install jq -y
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
         run: ./build/publish.sh
 
       - name: Upload build
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v7
         with:
           name: NuGet
           path: .artifacts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,4 @@ jobs:
         with:
           name: NuGet
           path: .artifacts/
+          include-hidden-files: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/dotnet/sdk:7.0
+    container: mcr.microsoft.com/dotnet/sdk:10.0
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Install jq
         run: |
@@ -26,7 +26,7 @@ jobs:
           apt-get install jq -y
 
       - name: Download build
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8
         with:
           name: NuGet
           path: .artifacts

--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -1,3 +1,7 @@
+### Breaking Changes V6
+
+- PlayerRank now targets .NET 10
+
 ### Breaking Changes V5
 
 - PlayerRank now targets .NET 7

--- a/src/PlayerRank.Tests/PlayerRank.Tests.csproj
+++ b/src/PlayerRank.Tests/PlayerRank.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlayerRank.Tests/PlayerRank.Tests.csproj
+++ b/src/PlayerRank.Tests/PlayerRank.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
 
     <LangVersion>Latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/PlayerRank/PlayerRank.csproj
+++ b/src/PlayerRank/PlayerRank.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Version>0.0.1.0</Version>
 
     <PackageVersion>0.0.1-local</PackageVersion>

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-    "next-version": "5.0",
+    "next-version": "6.0",
     "tag-prefix": "release/"
 }


### PR DESCRIPTION
## Summary
- Bump `TargetFrameworks` from `net7.0` (EOL May 2024) to `net10.0` (current LTS) in both `PlayerRank` and `PlayerRank.Tests`
- Update CI to build in the `mcr.microsoft.com/dotnet/sdk:10.0` container, and bump `actions/checkout` (v3->v7), `actions/upload-artifact` (v1->v7, deprecated by GitHub), and `actions/download-artifact` (v4.1.7->v8) to current versions
- Add a `github-actions` ecosystem entry to Dependabot so Actions versions get kept current automatically going forward (previously only NuGet was watched, which is how the above got so far behind)
- Bump `xunit` (2.9.2->2.9.3), `xunit.runner.visualstudio` (2.8.2->3.1.5), and `Microsoft.NET.Test.Sdk` (17.11.1->18.7.0) - routine patch/minor updates, still on xunit 2.x (not the xunit.v3 rewrite, which needs test code changes and is left for separate future work)
- Bump `version.json`'s `next-version` from `5.0` to `6.0` so the next release is `6.0.0` - the major bump signals that raising the minimum framework to net10.0 is a breaking change for consumers still on net7.0/net8.0

## Test plan
- [x] `dotnet build` - succeeds, 0 warnings/errors
- [x] `dotnet test` - 22/22 passing
- [x] `dotnet pack` - NuGet package builds successfully
- [ ] CI run on this PR confirms the updated container image and Actions versions work end-to-end