### PR TITLE
Add dependabot auto-approve workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    name: Dependabot auto-approve
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
+
+      # Minor and patch updates
+      - name: Approve PR and enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Major updates
+      - name: Comment on PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            This PR contains a major version update. Please find a human to review and approve it.
+          comment-tag: major-update


### PR DESCRIPTION
## Summary
- Adds a workflow that auto-approves and enables auto-merge for dependabot PRs that are patch or minor version updates
- Comments on major version update PRs asking for a human reviewer, instead of auto-approving them

Ported from [David.Eadie.Net](https://github.com/TheEadie/David.Eadie.Net/blob/main/.github/workflows/dependabot-auto-merge.yml) to reduce manual triage of routine dependency bumps.

## Test plan
- [ ] Confirm the workflow triggers on the next dependabot PR
- [ ] Verify patch/minor PRs get auto-approved and set to auto-merge
- [ ] Verify a major version PR (if/when one appears) gets the review-request comment instead